### PR TITLE
`VecDeque::partition_point` checks first element in `back` slice only once

### DIFF
--- a/library/alloc/src/collections/vec_deque/mod.rs
+++ b/library/alloc/src/collections/vec_deque/mod.rs
@@ -2782,10 +2782,14 @@ impl<T, A: Allocator> VecDeque<T, A> {
     where
         P: FnMut(&T) -> bool,
     {
-        let (front, back) = self.as_slices();
+        let (front, mut back) = self.as_slices();
 
         if let Some(true) = back.first().map(|v| pred(v)) {
-            back.partition_point(pred) + front.len()
+            back = unsafe {
+                // SAFETY: if clause has proven a first element to skip exists
+                back.get_unchecked(1..)
+            };
+            back.partition_point(pred) + front.len() + 1
         } else {
             front.partition_point(pred)
         }


### PR DESCRIPTION
I noticed that the first element of the `back` slice is potentially checked twice for the `partition_point` method, first in an if-condition and second inside the respective body.

In this change, the back slice is reduced by the first element and this offset is added to the result.

I am not sure how to trigger benchmarks for this, I assume doing this PR is the way to go for Bors.

Please tell me if this is not how pull requests should be done.